### PR TITLE
Support Laravel Dusk 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "laravel/dusk": "1.*|2.*|3.*|4.*"
+        "laravel/dusk": "1.*|2.*|3.*|4.*|5.*"
     },
     "require-dev": {
         "orchestra/testbench": "^3.7",


### PR DESCRIPTION
Using Laravel Dusk 5.* seems to work fine with the package, however it's not allowed in the composer file. This PR fixes that.